### PR TITLE
Don't return true when checking if value is in mask when mask isn't set

### DIFF
--- a/lib/attr_bitwise.rb
+++ b/lib/attr_bitwise.rb
@@ -234,9 +234,9 @@ module AttrBitwise
     values_or_symbols_array.each { |val| add_value(column_name, force_to_bitwise_value(val, mapping)) }
   end
 
-  # Return if value presents in mask (raw value)
+  # Return if value presents in mask (raw value) and mask set
   def value?(column_name, val)
-    send(column_name) & val != 0
+    ![0, false].include?(send(column_name) & val)
   end
 
   # add `value_or_symbol` to mask


### PR DESCRIPTION
Given the example in comments in `lib/attr_bitwise.rb` this is current functionality:

```ruby
MyModel.new.payment_type?(:slots)
=> true
```

This is unexpected since a new instance wouldn't have `payment_type_value` set, it is `nil`.  This fix makes `payment_type?` return `false` when `payment_type_value` column is `nil`.